### PR TITLE
[add] detect curried functions

### DIFF
--- a/src/parse-module.typ
+++ b/src/parse-module.typ
@@ -51,10 +51,19 @@
   let variable-docs = ()
 
   for match in matches {
-    if content.len() <= match.end or content.at(match.end) != "(" {
-      variable-docs.push(tidy-parse.parse-variable-docstring(content, match, parse-info))
+    
+    if content.len() <= match.end or content.at(match.end) != "("  {
+      let parent-info = tidy-parse.parse-curried-function(content, match.end)
+      let doc = tidy-parse.parse-variable-docstring(content, match, parse-info)
+      if parent-info == none {
+        variable-docs.push(doc)
+      } else {
+        doc.parent = parent-info
+        function-docs.push(doc)
+      }
     } else {
-      function-docs.push(tidy-parse.parse-function-docstring(content, match, parse-info))
+      let function-doc = tidy-parse.parse-function-docstring(content, match, parse-info)
+      function-docs.push(function-doc)
     }
   }
   

--- a/src/tidy-parse.typ
+++ b/src/tidy-parse.typ
@@ -368,8 +368,6 @@
   if sink != none { args.insert(sink, (:)) }
   
 
-  let parent = parse-curried-function(source-code, match.end + count)
-  
   for arg in documented-args {
     if arg.name in args {
       args.at(arg.name).description = arg.desc.trim("\n")
@@ -393,7 +391,6 @@
     name: fn-name, 
     description: description, 
     args: args, 
-    return-types: return-types,
-    parent: parent
+    return-types: return-types
   )
 }

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -170,11 +170,11 @@ assert.eq(result.functions.at(0).return-types, none)
 // Curried functions
 #{
   let code = ```
-  ///
-  #let f()=asd.with(a: 0, b: 1pt + red)
+  /// asd 
+  #let asg = asd.with(a: 0, b: 1pt + red)
   
   ///
-  #let g()  =  asg.with()
+  #let g =  asg.with()
   ```
 
   let result = parse-module(code.text)

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -4,6 +4,17 @@
 
 #let eval-string(string) = eval-docstring(string, (scope: (:)))
 
+
+#{
+  let code = ```
+  /// - alpha (str):
+  /// - beta (length):
+  // / - ..children (any):
+  #let z(alpha, beta: 2pt, ..children) = {}
+  ```
+  let k = parse-module(code.text)
+}
+
 // Test reference-matcher
 #{
   let matches = " @@func".matches(reference-matcher)
@@ -171,4 +182,17 @@ assert.eq(result.functions.at(0).return-types, none)
   let f2 = result.functions.at(1)
   assert.eq(f1.parent.name, "asd")
   assert.eq(f2.parent.name, "asg")
+}
+
+// module docstrings
+#{
+  let code = ```
+  /// This is a module
+  /// 
+  /// 
+
+  a
+  ```
+
+  let result = parse-module(code.text)
 }

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -23,9 +23,9 @@
 
 // Test argument-documentation-matcher
 #{
-  let matches = "   \t\n\t  /// - my-arg1 (str, content): desc".matches(argument-documentation-matcher)
+  let matches = "   \t\n\t  /// - my-arg1 (string, content): desc".matches(argument-documentation-matcher)
   assert.eq(matches.len(), 1)
-  assert.eq(matches.at(0).captures, ("my-arg1","str, content", "desc"))
+  assert.eq(matches.at(0).captures, ("my-arg1","string, content", "desc"))
 
   // multiline argument description
   let matches = "/// - arg (type): desc\n\tasd\n-3$234$".matches(argument-documentation-matcher)
@@ -92,11 +92,11 @@ assert.eq(result.functions.at(0).return-types, none)
 #{
   let a = ```
   /// Func
-  /// - p1 (str): a param $a$
+  /// - p1 (string): a param $a$
   /// - p2 (boolean, function): a param $b$
   ///        Oh yes
-  /// - p3 (str): 
-  /// -> content, int
+  /// - p3 (string): 
+  /// -> content, integer
   #let a(p1, p2: 2, p3: (), p4: ("entries": ())) = {}
   ```.text
   let result = parse-module(a)
@@ -106,15 +106,13 @@ assert.eq(result.functions.at(0).return-types, none)
   assert.eq(f0.name, "a")
   assert.eq(eval-string(f0.description), [Func])
   assert.eq(f0.args.len(), 4)
-  assert.eq(f0.args.p1.types, ("str",))
+  assert.eq(f0.args.p1.types, ("string",))
   assert.eq(eval-string(f0.args.p1.description), [a param $a$])
   assert.eq(f0.args.p2.default, "2")
   assert.eq(eval-string(f0.args.p2.description), [a param $b$ Oh yes])
   assert.eq(f0.args.p2.types, ("boolean", "function"))
-  assert.eq(f0.return-types, ("content", "int"))
+  assert.eq(f0.return-types, ("content", "integer"))
 }
-
-
 
 
 
@@ -144,3 +142,33 @@ assert.eq(result.functions.at(0).return-types, none)
   assert.eq(result.functions.len(), 0)
 }
 
+
+// Ensure that wide unicode characters don't disturb line calculation for error messages
+#{
+  let code = ```
+  // ⇒⇐ßáà€
+  
+  /// foo
+  /// >>> 2 == 2
+  #let f() 
+  ```
+
+  let result = show-module(parse-module(code.text))
+}
+
+// Curried functions
+#{
+  let code = ```
+  ///
+  #let f()=asd.with(a: 0, b: 1pt + red)
+  
+  ///
+  #let g()  =  asg.with()
+  ```
+
+  let result = parse-module(code.text)
+  let f1 = result.functions.first()
+  let f2 = result.functions.at(1)
+  assert.eq(f1.parent.name, "asd")
+  assert.eq(f2.parent.name, "asg")
+}

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -170,18 +170,29 @@ assert.eq(result.functions.at(0).return-types, none)
 // Curried functions
 #{
   let code = ```
-  /// asd 
-  #let asg = asd.with(a: 0, b: 1pt + red)
-  
-  ///
-  #let g =  asg.with()
+/// - foo (content): Something.
+/// - bar (boolean): A boolean.
+/// -> content
+#let myfunc(foo, bar: false) = strong(foo)
+
+/// My curried function.
+/// -> content
+#let curried = myfunc.with(bar: true, 2)
   ```
 
   let result = parse-module(code.text)
-  let f1 = result.functions.first()
+  let f1 = result.functions.at(0)
   let f2 = result.functions.at(1)
-  assert.eq(f1.parent.name, "asd")
-  assert.eq(f2.parent.name, "asg")
+  assert.eq(f1.name, "myfunc")
+  assert.eq(f2.parent.name, "myfunc")
+  assert.eq(f2.parent.pos, ("2",))
+  assert.eq(f2.parent.named, (bar: "true"))
+  assert.eq(f2.args.len(), 1)
+  assert.eq(f2.args.bar, (
+    default: "true",
+    description: "A boolean.",
+    types: ("boolean",),
+  ))
 }
 
 // module docstrings


### PR DESCRIPTION
Declarations that pre-apply arguments to a function (so-called curried functions), e.g., 
```typ
#let my-rect = rect.with(stroke: purple)
```
are now detected as functions and information about the parent is stored in the documentation information. The function inherits all information from the "parent" function. Argument defaults are updated and positional arguments dropped if they are pre-applied in the definition. 

Additionally, the information for a curried function contains an entry for the key `parent` with the `name` and the pre-applied `pos` and `named` arguments. 

Closes #20 