### PR TITLE
[add] parse module descriptions

### DIFF
--- a/src/parse-module.typ
+++ b/src/parse-module.typ
@@ -84,6 +84,8 @@
     label-prefix: label-prefix,
     require-all-parameters: require-all-parameters,
   )
+
+  let module-docstring = tidy-parse.parse-module-docstring(content, parse-info)
   
   let matches = content.matches(tidy-parse.docstring-matcher)
   let function-docs = ()
@@ -117,6 +119,7 @@
   
   return (
     name: name,
+    description: module-docstring,
     functions: function-docs, 
     variables: variable-docs, 
     label-prefix: label-prefix,

--- a/src/tidy-parse.typ
+++ b/src/tidy-parse.typ
@@ -367,7 +367,7 @@
   for (arg, value) in named { args.insert(arg, (default: value)) }
   if sink != none { args.insert(sink, (:)) }
   
-
+  
   for arg in documented-args {
     if arg.name in args {
       args.at(arg.name).description = arg.desc.trim("\n")
@@ -393,4 +393,14 @@
     args: args, 
     return-types: return-types
   )
+}
+
+
+#let module-docstring-matcher = regex(`(?m)^((?:[^\S\r\n]*///.*\n)+)\n`.text)
+
+#let parse-module-docstring(source-code, parse-info) = {
+  let match = source-code.match(module-docstring-matcher)
+  if match == none { return none }
+  let desc = parse-description-and-documented-args(match.captures.first(), parse-info, first-line-number: 0) 
+  return desc.description.trim()
 }

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -195,9 +195,11 @@ assert.eq(result.functions.at(0).return-types, none)
   ))
 }
 
-// module docstrings
+// module description
 #{
   let code = ```
+  // License
+
   /// This is a module
 
   a

--- a/tests/test_parse.typ
+++ b/tests/test_parse.typ
@@ -199,11 +199,10 @@ assert.eq(result.functions.at(0).return-types, none)
 #{
   let code = ```
   /// This is a module
-  /// 
-  /// 
 
   a
   ```
 
   let result = parse-module(code.text)
+  assert.eq(result.description, "This is a module")
 }


### PR DESCRIPTION
This change adds support for module descriptions. Module descriptions consist of a normal doc comment that is not attached to any declaration. A normal license comment is allowed at the top of the file

```typ
// License text...
// ...

/// This is the module description. 
/// ...


let myvar = 2
```