### PR TITLE
[add] native cross-ref syntax

### DIFF
--- a/docs/template.typ
+++ b/docs/template.typ
@@ -88,7 +88,7 @@
   body
 }
 
-#let ref-fn(name) = link(label("tidy" + name), raw(name))
+#let ref-fn(name) = link(label("tidy-" + name), raw(name))
 
 #let file-code(filename, code) = pad(x: 4%, block(
   width: 100%, 

--- a/src/helping.typ
+++ b/src/helping.typ
@@ -20,7 +20,7 @@
   if type(entry) != array {
     entry = (entry,)
   }
-  parse-module(entry.map(x => x()).join("\n"), old-parser: old-parser)
+  parse-module(entry.map(x => x()).join("\n"), old-parser: old-parser, label-prefix: "help-")
 }
 
 #let search-docs(search, searching, namespace, style, old-parser: false) = {
@@ -55,7 +55,7 @@
   module.variables = variables
   return help-box({ 
     show search: highlight.with(fill: rgb("#FF28")) 
-    show-module(module, style: style)
+    show-module(module, style: style, enable-cross-references: false)
   })
 }
 
@@ -173,7 +173,7 @@
       style: style,
       enable-cross-references: false,
       enable-tests: false,
-      show-outline: false
+      show-outline: false,
     )
   }
   return result

--- a/src/parse-module.typ
+++ b/src/parse-module.typ
@@ -100,7 +100,7 @@
 /// - `types` (optional): A list of accepted argument types. 
 /// - `default` (optional): Default value for this argument.
 /// 
-/// See @@show-module() for outputting the results of this function.
+/// See @show-module for outputting the results of this function.
 #let parse-module(
   
   /// Content of `.typ` file to analyze for docstrings. 
@@ -137,7 +137,7 @@
   /// -> boolean
   old-parser: true
 ) = {
-  if label-prefix == auto { label-prefix = name }
+  if label-prefix == auto { label-prefix = name + "-" }
   
   let docs = (
     name: name,

--- a/src/show-module.typ
+++ b/src/show-module.typ
@@ -3,6 +3,8 @@
 #import "testing.typ"
 
 
+#let def-state = state("tidy-definitions", (:))
+
 
 /// Show given module in the given style.
 /// This displays all (documented) functions in the module.
@@ -10,7 +12,7 @@
 /// -> content
 #let show-module(
   
-  /// Module documentation information as returned by @@parse-module(). 
+  /// Module documentation information as returned by @parse-module. 
   /// -> dictionary
   module-doc, 
 
@@ -27,7 +29,7 @@
   /// -> int
   first-heading-level: 2,
 
-  /// Whether to output the name of the module at the top.  
+  /// Whether to output the name of the module at the top. 
   /// -> boolean
   show-module-name: true,
 
@@ -126,6 +128,23 @@
 
   style-args.scope = eval-scope
   
+  def-state.update(x => {
+    x + module-doc.functions.map(x => (x.name, 1)).to-dict() + module-doc.variables.map(x => (x.name, 0)).to-dict()
+  })
+
+  show ref: it => {
+    let target = str(it.target)
+    if target.starts-with(label-prefix){ return it }
+    if not enable-cross-references {
+      return raw(target)
+    }
+    let defs = def-state.final()
+    if defs.at(target, default: none) == 1 {
+      target += "()"
+    }
+    (eval-scope.tidy.show-reference)(label(label-prefix + target), target)
+  }
+
 
   // Show the docs
   

--- a/src/styles/default.typ
+++ b/src/styles/default.typ
@@ -119,7 +119,7 @@
 
 // Create a parameter description block, containing name, type, description and optionally the default value. 
 #let show-parameter-block(
-  name, types, content, style-args,
+  function-name: none, name, types, content, style-args,
   show-default: false, 
   default: none, 
 ) = block(
@@ -127,6 +127,7 @@
   breakable: style-args.break-param-descriptions,
   [
     #box(heading(level: style-args.first-heading-level + 3, name))
+    #if function-name != none and style-args.enable-cross-references { label(function-name + "." + name) }
     #h(1.2em) 
     #types.map(x => (style-args.style.show-type)(x, style-args: style-args)).join([ #text("or",size:.6em) ])
   
@@ -142,11 +143,11 @@
 
   if style-args.colors == auto { style-args.colors = colors }
 
-  if style-args.enable-cross-references [
+  [
     #heading(fn.name, level: style-args.first-heading-level + 1)
-    #label(style-args.label-prefix + fn.name + "()")
-  ] else [
-    #heading(fn.name, level: style-args.first-heading-level + 1)
+    #if style-args.enable-cross-references {
+      label(style-args.label-prefix + fn.name + "()")
+    }
   ]
   
   eval-docstring(fn.description, style-args)
@@ -168,6 +169,7 @@
       style-args,
       show-default: "default" in info, 
       default: info.at("default", default: none),
+      function-name: style-args.label-prefix + fn.name
     )
   }
   v(4.8em, weak: true)

--- a/src/styles/help.typ
+++ b/src/styles/help.typ
@@ -13,7 +13,8 @@
   let prefix = module-doc.label-prefix
   let items = ()
   for fn in module-doc.functions {
-    items.push(link(label(prefix + fn.name + "()"), fn.name + "()"))
+    items.push(fn.name + "()")
+    // items.push(link(label(prefix + fn.name + "()"), fn.name + "()"))
   }
   list(..items)
 }

--- a/src/styles/minimal.typ
+++ b/src/styles/minimal.typ
@@ -68,6 +68,7 @@
   name, types, content, style-args,
   show-default: false, 
   default: none, 
+  function-name: none
 ) = block(
   inset: 0pt, width: 100%,
   breakable: style-args.break-param-descriptions,
@@ -75,6 +76,7 @@
     #[
       #set text(fill: fn-color)
       #raw(name, lang: none) 
+      #if function-name != none and style-args.enable-cross-references { label(function-name + "." + name) }
     ]
     (#h(-.2em)
     #types.map(x => (style-args.style.show-type)(x)).join([ #text("or",size:.6em) ])
@@ -91,14 +93,12 @@
 ) = {
   set par(justify: false, hanging-indent: 1em, first-line-indent: 0em)
 
-  block(breakable: style-args.break-param-descriptions, 
-    if style-args.enable-cross-references [
-      #(style-args.style.show-parameter-list)(fn, style-args)
-      #label(style-args.label-prefix + fn.name + "()")
-    ] else [
-      #(style-args.style.show-parameter-list)(fn, style-args)
-    ]
-  )
+  block(breakable: style-args.break-param-descriptions)[
+    #(style-args.style.show-parameter-list)(fn, style-args)
+    #if style-args.enable-cross-references {
+      label(style-args.label-prefix + fn.name + "()")
+    }
+  ]
   pad(x: 0em, eval-docstring(fn.description, style-args))
 
   let parameter-block
@@ -115,6 +115,7 @@
       style-args,
       show-default: "default" in info, 
       default: info.at("default", default: none),
+      function-name: style-args.label-prefix + fn.name
     )
   }
   


### PR DESCRIPTION
Cross-references are not anymore handled via special `@@` syntax but with native Typst reference syntax. Addresses the second point in #32 . 


Todo:
- [x] Support cross-references to functions and variables. 
- [x] Automatic discrimination between functions and variables. 
- [x] Support cross-references to parameters. 