### PR TITLE
[add] show rule on `raw` for examples

### DIFF
--- a/docs/tidy-guide.typ
+++ b/docs/tidy-guide.typ
@@ -139,7 +139,7 @@ We can now parse the module and pass the module `wiggly` through the `scope` par
   read("wiggly.typ"), 
   name: "wiggly",
   scope: (wiggly: wiggly),
-  preamble: "import wiggly: *;"
+  preamble: "#import wiggly: *\n"
 )
 ```
 
@@ -152,7 +152,7 @@ In the output, the preview of the code examples is shown next to it.
     read("/examples/wiggly.typ"), 
     name: "wiggly",
     scope: (wiggly: wiggly),
-    preamble: "import wiggly: draw-sine;", 
+    preamble: "#import wiggly: *\n", 
     old-parser: false
   )
   tidy-output-figure(tidy.show-module(module, show-outline: false))
@@ -255,7 +255,7 @@ Currently, the two predefined styles `tidy.styles.default` and `tidy-styles.mini
     read("/examples/wiggly.typ"), 
     name: "wiggly",
     scope: (wiggly: wiggly),
-    preamble: "import wiggly: *;",
+    preamble: "#import wiggly: *\n",
     old-parser: false
   )
   tidy-output-figure(tidy.show-module(module, show-outline: false, style: tidy.styles.minimal))

--- a/examples/wiggly.typ
+++ b/examples/wiggly.typ
@@ -1,7 +1,10 @@
 /// Draw a sine function with $n$ periods into a rectangle of given size.
 ///
 /// *Example:*
-/// #example(`draw-sine(1cm, 0.5cm, 2)`)
+/// 
+/// ```example
+/// #draw-sine(1cm, 0.5cm, 2)
+/// ```
 ///
 /// -> content
 #let draw-sine(
@@ -13,8 +16,11 @@
   height, 
   
   /// Number of periods to draw. 
-  ///      Example with many periods: 
-  ///      #example(`draw-sine(4cm, 1.3cm, 10)`)
+  /// 
+  /// Example with many periods: 
+  /// ```example
+  /// #draw-sine(4cm, 1.3cm, 10)
+  /// ```
   /// -> int | float
   periods
 ) = box(width: width, height: height, {

--- a/src/show-example.typ
+++ b/src/show-example.typ
@@ -33,6 +33,10 @@
   col-spacing: 5pt,
   ..options
 ) = {
+  let content = code.text
+  let displayed-code = code.text.split("\n").filter(x => not x.starts-with(">>>")).join("\n")
+  let executed-code = code.text.split("\n").map(x => x.trim(">>>", at: start)).join("\n")
+  
   let lang = if code.has("lang") { code.lang } else { "typc" }
   if mode == auto {
     if lang == "typ" { mode = "markup" }
@@ -41,11 +45,12 @@
   if mode == "markup" and not code.has("lang") { 
     lang = "typ" 
   }
+  code = raw(displayed-code, lang: lang, block: true)
   if code.has("block") and code.block == false {
-    code = raw(code.text, lang: lang, block: true)
+    // code = raw(code.text, lang: lang, block: true)
   }
         
-  let preview = [#eval(preamble + code.text, mode: mode, scope: scope + inherited-scope)]
+  let preview = [#eval(preamble + executed-code, mode: mode, scope: scope + inherited-scope)]
   
   let preview-outer-padding = 5pt
   let preview-inner-padding = 5pt
@@ -118,4 +123,16 @@
       else { measure(arrangement(width: size.width)).height }
     arrangement(height: height)
   })
+}
+
+#let render-examples(body) = {
+  show raw.where(lang: "example"): it => {
+    set text(4em / 3)
+
+    show-example(
+      raw(it.text, block: true, lang: "typ"), 
+      mode: "markup"
+      )
+  }
+  body
 }

--- a/src/show-module.typ
+++ b/src/show-module.typ
@@ -145,6 +145,14 @@
     (eval-scope.tidy.show-reference)(label(label-prefix + target), target)
   }
 
+  show raw.where(lang: "example"): it => {
+    set text(4em / 3)
+
+    (eval-scope.example)(
+      raw(it.text, block: true, lang: "typ"), 
+      mode: "markup"
+      )
+  }
 
   // Show the docs
   

--- a/src/tidy.typ
+++ b/src/tidy.typ
@@ -5,7 +5,7 @@
 #import "old-parser.typ" as tidy-parse
 #import "utilities.typ"
 #import "testing.typ"
-#import "show-example.typ"
+#import "show-example.typ" as show-example: render-examples
 #import "parse-module.typ": parse-module
 #import "show-module.typ": show-module
 #import "helping.typ" as helping: generate-help


### PR DESCRIPTION
This adds a show rule for `raw` elements with the languages
- `example` (for Typst markup)
- `examplec` (for Typst code mode)
that will transform them into the code displayed side-by-side with the rendered output. 

## Usage
This show rule can be used standalone via the function `render-examples()`. 
````typ
#import "@preview/tidy:0.4.0": render-examples
#show: render-examples

```example
#rect()
```

```examplec
rect()
```
````

## Scope
It also features a `scope` argument, that can be pre-set

````typ
#show: render-examples.with(scope: (#answer: 42))

```example
#answer
```
````

## Hidden code
It is possible to add _hidden_ code that will be executed but not shown on lines starting with `>>>`. This is useful for import statements, wrapping everything inside a container of a fixed size and other things. 

```typ
>>> #let read(filename) = "Content of a file we cannot access. " // This line is executed but not shown 
#read("my-file.txt")
```
This is inspired by the Typst documentation. 