### PR TITLE
Support locale option for variables title in outline

### DIFF
--- a/src/show-module.typ
+++ b/src/show-module.typ
@@ -75,9 +75,9 @@
 
   /// Language-specific names for strings used in the output. Currently, these 
   /// are `parameters` and `default`. You can for example use: 
-  /// `local-names: (parameters: [Paramètres], default: [défault])`.
+  /// `local-names: (parameters: [Paramètres], default: [Défault], variables: [Alterné])`.
   /// -> dictionary
-  local-names: (parameters: [Parameters], default: [Default])
+  local-names: (parameters: [Parameters], default: [Default], variables: [Variables])
 ) = block({
   let label-prefix = module-doc.label-prefix
   if sort-functions == auto { 

--- a/src/show-module.typ
+++ b/src/show-module.typ
@@ -75,7 +75,7 @@
 
   /// Language-specific names for strings used in the output. Currently, these 
   /// are `parameters` and `default`. You can for example use: 
-  /// `local-names: (parameters: [Paramètres], default: [Défault], variables: [Alterné])`.
+  /// `local-names: (parameters: [Parameter], default: [Standard], variables: [Variablen])`.
   /// -> dictionary
   local-names: (parameters: [Parameters], default: [Default], variables: [Variables])
 ) = block({

--- a/src/styles/default.typ
+++ b/src/styles/default.typ
@@ -76,7 +76,7 @@
   }
     
   if module-doc.variables.len() > 0 {
-    text([Variables:], weight: "bold")
+    text(style-args.local-names.at("variables"), weight: "bold")
     list(..module-doc.variables.map(var => gen-entry(var.name)))
   }
 }

--- a/src/styles/minimal.typ
+++ b/src/styles/minimal.typ
@@ -21,7 +21,7 @@
   }
     
   if module-doc.variables.len() > 0 {
-    text([Variables:], weight: "bold")
+    text(style-args.local-names.at("variables"), weight: "bold")
     list(..module-doc.variables.map(var => gen-entry(var.name)))
   }
 }


### PR DESCRIPTION
I added locales support for variable title in default styles outlines 

```typst
/// `local-names: (parameters: [Paramètres], default: [Défault], variables: [Alterné])`.
/// -> dictionary
local-names: (parameters: [Parameters], default: [Default], variables: [Variables])
```

Closes #47

However it seems to me that supporting `#set text(lang: ...)` will be full solution, this one is partial